### PR TITLE
Add GitHub Actions CI.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,8 +4,13 @@ on:
   pull_request:
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
+      matrix:
+        os:
+          - ubuntu-22.04
+          - ubuntu-20.04
+          - ubuntu-18.04
       fail-fast: false
     env:
       MERQURY_FK_DEST_DIR: /tmp/bin


### PR DESCRIPTION
I prepared the GitHub Actions CI for this repository. I tested it on my forked repository and confirmed it passes. The CI result is [here](https://github.com/junaruga/MERQURY.FK/actions/runs/3015659405).

There are 2 commits for this PR. The 1st commit is to add one test case for the `ubuntu-latest` (= ubuntu 20.04). The second commit is to update the CI config to test with all the available ubuntu versions and the default GCC versions below.

* ubuntu-22.04 - GCC version 11.2.0
* ubuntu-20.04 - GCC version 9.4.0
* ubuntu-18.04 - GCC version 7.5.0

You can see [this official document](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners
) for the supported platforms for details.

## Examples

Here are some cases in other projects.

* hifiasm: https://github.com/chhylp123/hifiasm/blob/master/.github/workflows/ci.yaml
* minimap2: https://github.com/lh3/minimap2/blob/master/.github/workflows/ci.yaml
* bowtie2: https://github.com/BenLangmead/bowtie2/tree/master/.github/workflows
* ruby: https://github.com/ruby/ruby/tree/master/.github/workflows
